### PR TITLE
pass the input key to inner chain in RetrivalQAChain

### DIFF
--- a/langchain-core/src/main/java/com/hw/langchain/chains/retrieval/qa/base/BaseRetrievalQA.java
+++ b/langchain-core/src/main/java/com/hw/langchain/chains/retrieval/qa/base/BaseRetrievalQA.java
@@ -77,7 +77,8 @@ public abstract class BaseRetrievalQA extends Chain {
         var question = inputs.get(inputKey).toString();
 
         List<Document> docs = getDocs(question);
-        String answer = combineDocumentsChain.run(Map.of("input_documents", docs, "question", question));
+        inputs.put("input_documents", docs);
+        String answer = combineDocumentsChain.run(inputs);
 
         Map<String, String> result = Maps.newHashMap();
         result.put(outputKey, answer);


### PR DESCRIPTION
Currently, in retrivalQA chain, only `question` and `input_documents` are passed into inner chain.  If the prompt template of LLMChain has more input keys, it can't be formatted correctly.

In this merge request, we passed all input keys to inner chain. 