### PR TITLE
fix bug: exception at BaseCombineDocumentsChain when use BaseRetrievalQA, as missing key [question]

### DIFF
--- a/langchain-core/src/main/java/com/hw/langchain/chains/retrieval/qa/base/BaseRetrievalQA.java
+++ b/langchain-core/src/main/java/com/hw/langchain/chains/retrieval/qa/base/BaseRetrievalQA.java
@@ -79,7 +79,9 @@ public abstract class BaseRetrievalQA extends Chain {
 
         List<Document> docs = getDocs(question);
         inputs.put("input_documents", docs);
-        inputs.put("question", question);
+        if (!inputs.containsKey("question")) {
+            inputs.put("question", question);
+        }
         String answer = combineDocumentsChain.run(inputs);
 
         Map<String, String> result = Maps.newHashMap();

--- a/langchain-core/src/main/java/com/hw/langchain/chains/retrieval/qa/base/BaseRetrievalQA.java
+++ b/langchain-core/src/main/java/com/hw/langchain/chains/retrieval/qa/base/BaseRetrievalQA.java
@@ -79,6 +79,7 @@ public abstract class BaseRetrievalQA extends Chain {
 
         List<Document> docs = getDocs(question);
         inputs.put("input_documents", docs);
+        inputs.put("question", question);
         String answer = combineDocumentsChain.run(inputs);
 
         Map<String, String> result = Maps.newHashMap();


### PR DESCRIPTION
use RetrievalQa lead to exception:
```
java.lang.IllegalArgumentException: Missing some input keys: [question]

	at com.hw.langchain.chains.base.Chain.validateInputs(Chain.java:58)
	at com.hw.langchain.chains.base.Chain.prepInputs(Chain.java:158)
	at com.hw.langchain.chains.base.Chain.call(Chain.java:102)
	at com.hw.langchain.chains.llm.LLMChain.predict(LLMChain.java:164)
	at com.hw.langchain.chains.combine.documents.stuff.StuffDocumentsChain.combineDocs(StuffDocumentsChain.java:116)
	at com.hw.langchain.chains.combine.documents.base.BaseCombineDocumentsChain.innerCall(BaseCombineDocumentsChain.java:73)
	at com.hw.langchain.chains.base.Chain.call(Chain.java:103)
	at com.hw.langchain.chains.base.Chain.run(Chain.java:183)
	at com.hw.langchain.chains.retrieval.qa.base.BaseRetrievalQA.innerCall(BaseRetrievalQA.java:82)
	at com.hw.langchain.chains.base.Chain.call(Chain.java:103)
	at com.hw.langchain.chains.base.Chain.call(Chain.java:89)
	at com.hw.langchain.chains.base.Chain.run(Chain.java:171)
```

as LLMChain request key names `question` defined in StuffPrompt.PROMPT_TEMPLATE, but never auto set this variables by `BaseRetrievalQA.run(String query)`.
I have fix it when setting variable 'input_documents' in BaseRetrievalQA
