### PR TITLE
Update the description about Support in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ mvn spotless:apply
 ## 6. Support
 Don’t hesitate to ask!
 
-[Open an issue](https://github.com/HamaWhiteGG/langchain-java/issues) if you find a bug in Flink.
+[Open an issue](https://github.com/HamaWhiteGG/langchain-java/issues) if you find a bug in langchain-java.
 
 ## 7. Fork and Contribute
 This is an active open-source project. We are always open to people who want to use the system or contribute to it. Please note that pull requests should be merged into the **dev** branch.


### PR DESCRIPTION
The description about Support in README.md should be langchain-java instead of Flink.