### PR TITLE
hold "warning" filed when test in deprecated model like "text-davinci-003"

### DIFF
--- a/openai-client/src/main/java/com/hw/openai/entity/completions/CompletionResp.java
+++ b/openai-client/src/main/java/com/hw/openai/entity/completions/CompletionResp.java
@@ -29,6 +29,8 @@ import java.util.List;
 @Data
 public class CompletionResp {
 
+    private String warning;
+
     private String id;
 
     private String object;


### PR DESCRIPTION
the default completion model "text-davinci-003" is deprecated, a warning field appeared unexpected when run LLMChainTest.testLLMChainWithOneInputVariables.


resp looks like:
{
  "warning": "This model version is deprecated. Migrate before January 4, 2024 to avoid disruption of service. Learn more https://platform.openai.com/docs/deprecations",
  "id": "cmpl-7jTUpXmJZSjbeWtljF6NykqeQMIYo",
  "object": "text_completion",
  "created": 1691072499,
  "model": "text-davinci-003",
...
}


the crash report looks like:
java.lang.RuntimeException: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "warning" (class com.hw.openai.entity.completions.CompletionResp), not marked as ignorable (6 known properties: "usage", "choices", "created", "model", "id", "object"])
