### PR TITLE
修复在使用Agent时解析Json以及参数转换的BUG

### DIFF
--- a/langchain-core/src/main/java/com/hw/langchain/agents/chat/output/parser/ChatOutputParser.java
+++ b/langchain-core/src/main/java/com/hw/langchain/agents/chat/output/parser/ChatOutputParser.java
@@ -38,6 +38,9 @@ public class ChatOutputParser extends AgentOutputParser {
 
     private static final String FINAL_ANSWER_ACTION = "Final Answer:";
 
+    private static Gson GSON_JSON = new GsonBuilder()
+            .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+            .create();
     @Override
     public AgentResult parse(String text) {
         boolean includesAnswer = text.contains(FINAL_ANSWER_ACTION);
@@ -45,8 +48,10 @@ public class ChatOutputParser extends AgentOutputParser {
             String action = text.split("```")[1];
             Type mapType = new TypeToken<Map<String, Object>>() {
             }.getType();
-            Map<String, Object> response = new Gson().fromJson(action.strip(), mapType);
-
+            /*
+             * 20230308:修复通过GSON反序列化时将long类型的数值错误的转成了double类型科学计数法
+             * */
+            Map<String, Object> response = GSON_JSON.fromJson(action.strip(),mapType);
             boolean includesAction = response.containsKey("action") && response.containsKey("action_input");
             if (includesAnswer && includesAction) {
                 throw new OutputParserException(

--- a/langchain-core/src/main/java/com/hw/langchain/tools/base/BaseTool.java
+++ b/langchain-core/src/main/java/com/hw/langchain/tools/base/BaseTool.java
@@ -91,13 +91,15 @@ public abstract class BaseTool {
     public abstract Object innerRun(String args, Map<String, Object> kwargs);
 
     public Pair<Object[], Map<String, Object>> toArgsAndKwargs(Object toolInput) {
-        if (toolInput instanceof String) {
-            return Pair.of(new Object[]{toolInput}, Maps.newHashMap());
-        } else {
-            @SuppressWarnings("unchecked")
+        /*
+        * 20230308:入参为Map时转换，否则不进行转换
+        * 原逻辑入参为非String和非Map时会出现将toolInput强转为Map报错
+        * */
+        if(toolInput instanceof Map){
             Map<String, Object> mapInput = (Map<String, Object>) toolInput;
             return Pair.of(new Object[]{}, mapInput);
         }
+        return Pair.of(new Object[]{toolInput}, Maps.newHashMap());
     }
 
     /**


### PR DESCRIPTION

1. 修复通过GSON反序列化时将long类型的数值错误的转成了double类型科学计数法https://github.com/HamaWhiteGG/langchain-java/commit/58cad5beea63b9a2d59730b2952f61e9b00366c1)

2.原逻辑入参为非String和非Map时会出现将toolInput强转为Map报错]
https://github.com/HamaWhiteGG/langchain-java/commit/bd12e16638949236c161cae345b554cdb1aa21b9)